### PR TITLE
Implemented UI for Join Tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17399,6 +17399,7 @@
     },
     "eslint-config-hackreactor": {
       "version": "git+ssh://git@github.com/reactorcore/eslint-config-hackreactor.git#9111851f7214ed3e2817542b3777765bda3df98d",
+      "integrity": "sha512-NPOyEwd7cEh0NqSZmdeoPSiSg0/LSHFu4f7vIiXjjjFMLduUdA31S6DXoOncE/pznCWP9ZuxvoncxF7HXqzCJQ==",
       "dev": true,
       "from": "eslint-config-hackreactor@github:reactorcore/eslint-config-hackreactor"
     },

--- a/src/features/ExploreView/Explore.Screen.js
+++ b/src/features/ExploreView/Explore.Screen.js
@@ -2,12 +2,30 @@ import React from 'react';
 import { StyleSheet, Text, View, Image } from 'react-native';
 import ExploreHeader from './ExploreHeader';
 import SafeArea from '../../components/SafeArea';
+import { colors } from '../../infrastructure/colors';
+
+
+const styles = StyleSheet.create({
+  exploreTitle: {
+    color: colors.brand.kazan,
+    fontSize: 24,
+  },
+
+  exploreTitleContainer: {
+    // flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around'
+  }
+});
 
 const ExploreScreen = () => {
   return (
     <SafeArea>
       <View>
         <ExploreHeader />
+        <View style={styles.exploreTitleContainer}>
+          <Text style={styles.exploreTitle}>Testing</Text>
+        </View>
       </View>
     </SafeArea>
   );

--- a/src/features/JoinView/Join.Screen.js
+++ b/src/features/JoinView/Join.Screen.js
@@ -1,14 +1,34 @@
 import React from 'react';
-import { StyleSheet, Text, View, Image } from 'react-native';
+import { StyleSheet, TouchableOpacity, Text, View, Image } from 'react-native';
 import SafeArea from '../../components/SafeArea';
+import GuestQR from '../GuestQR.js';
 import JoinScreenHeader from './JoinScreenHeader';
+import { colors } from '../../infrastructure/colors';
 
+
+const styles = StyleSheet.create({
+  joinContainer: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    marginTop: 200
+  }
+});
 
 const JoinScreen = ({ route, navigation }) => {
+  const scanQrCodeImage = '../../../assets/qr-code-image.png';
+  //inserting <GuestQR/> does not open the QR reader on my phone
   return (
     <SafeArea>
       <View>
         <JoinScreenHeader />
+        <View style={styles.joinContainer}>
+          <TouchableOpacity onPress={() => alert('image clicked!')}>
+            <Image
+              source={require(scanQrCodeImage)}
+            />
+          </TouchableOpacity>
+          <Text>Scan QR code to join</Text>
+        </View>
       </View>
     </SafeArea>
   );


### PR DESCRIPTION
## Description
Join tab displays the 'Scan QR code to join' image and text.

## How to test
When user opens the join tab, user can see an image, and some text that says 'Scan QR code to join.'
When you press on the image an alert window pops up saying 'Image clicked!'

## Notes
I used TouchableOpacity to make the image pressable. 

Also, I see that Crystal has coded GuestQR.js! I am unable to invoke GuestQR in the Join.Screen.js, even though I can successfully open the snack using expo. 

Essentially, when the user presses on the image, we want GuestQR to be invoked. Currently, an alert pop up is being invoked.

## Issue tracking
https://trello.com/c/Ktak926N/12-join-tab