### PR TITLE
bug fix

### DIFF
--- a/src/features/CurrentSessionView/CurrentSession.Screen.js
+++ b/src/features/CurrentSessionView/CurrentSession.Screen.js
@@ -53,7 +53,7 @@ const CurrentSessionScreen = ({route, navigation}) => {
       setCurrentTab('Menu');
     }
 
-  }, []);
+  }, [route.params]);
 
   return (
     <SafeArea>

--- a/src/features/CurrentSessionView/currentSessionSummary/GuestList.js
+++ b/src/features/CurrentSessionView/currentSessionSummary/GuestList.js
@@ -16,7 +16,7 @@ const GuestList = () => {
   const { state: { guests, accountHolderName, sessionId, nickname }, dispatch } = useContext(BiteShareContext);
 
   useEffect(() => {
-    if (guests.length && guests.every((guest) => guest.orderStatus === 'ready')) {
+    if (guests.length && guests.filter((guest) => guest.joinRequest === 'allowed').every((guest) => guest.orderStatus === 'ready')) {
       dispatch({ type: 'SET_ORDER_STATUS', isEveryoneReady: true });
     }
   }, [guests]);

--- a/src/features/CurrentSessionView/currentSessionSummary/SplitBillOptions.js
+++ b/src/features/CurrentSessionView/currentSessionSummary/SplitBillOptions.js
@@ -45,12 +45,12 @@ const SplitBillOptions = ({ changeTab }) => {
       .then(() => readASingleDocument('transactions', sessionId))
       .then((result) => {
         const totalBill = result.data().totalBills;
-        const guestCount = guests.length;
+        const guestCount = guests.filter(guest => guest.joinRequest === 'allowed').length;
         const updatedIndividualBill = totalBill / guestCount;
         guests.forEach((guest) => {
           getADocReferenceFromCollection(`transactions/${sessionId}/attendees`, 'name', '==', guest.name)
             .then((qResult) => {
-              qResult.forEach((doc) => {
+              qResult.filter(doc => doc.data().joinRequest === 'allowed').forEach((doc) => {
                 updateADocument(`transactions/${sessionId}/attendees`, doc.id, {
                   individualBills: updatedIndividualBill,
                 });


### PR DESCRIPTION
## Description
<!-- A short description for the purpose of this PR -->
- Filter for only guests that are allowed in the session when calculating the bill
- I noticed the host is not always taken to the `current session - QR` tab, sometimes is taken to the `current session - menu` tab instead, so I added a dependency for the `useEffect` hook used so that it rerenders not only on first load but also when the dependency changes.

## How to test
<!-- How could this PR be tested? (e.g. unit tests, instructions for manual test) -->
1. Create a session as a host
2. Join a session as a guest
3. host: deny the guest request
4. host: go to `menu` tab and order sth -> click "I'm ready" -> the status indicator on summary tab should show 'Everyone is ready' -> click 'Evenly' -> check in DB for individual bills, the individual bill for the denied guest should not change
4. repeat step 1 and 2, host: allow the guest request -> remove the guest from the list
5. repeat step 4

## Notes
<!-- Additional things reviewers should be aware of -->

## Issue tracking
<!-- Link to Trello ticket -->