### PR TITLE
Bills Screen

### DIFF
--- a/src/BiteShareContext.js
+++ b/src/BiteShareContext.js
@@ -4,7 +4,6 @@ import React from 'react';
 export const biteShareState = {
   isEveryoneReady: false,
   splitMethod: '',
-  totalBill: 0,
   guests: [],
   restaurants: [], //restaurants displayed in ExplorePage
   restaurantsImages: [], //images for ExplorePage
@@ -17,7 +16,7 @@ export const biteShareState = {
   orderedItems: [], //matching the name with TJ's code in Guest.js (will updated as needed after checking with TJ)
   email: '',
   authenticated: false,
-  biteShareKey: '',
+  biteShareKey: '16bcb6bcff21e2fbcbad3fd5c5ca4605',
   nickname: null
 };
 
@@ -28,8 +27,6 @@ export const biteShareReducer = (state, action) => {
       return { ...state, isEveryoneReady: action.isEveryoneReady };
     case 'SET_SPLIT_METHOD':
       return { ...state, splitMethod: action.splitMethod };
-    case 'SET_TOTAL_BILL':
-      return { ...state, totalBill: action.totalBill };
     case 'SET_GUESTS':
       return { ...state, guests: action.guests };
     case 'SET_RESTAURANTS':

--- a/src/BiteShareContext.js
+++ b/src/BiteShareContext.js
@@ -17,7 +17,7 @@ export const biteShareState = {
   orderedItems: [], //matching the name with TJ's code in Guest.js (will updated as needed after checking with TJ)
   email: '',
   authenticated: false,
-  biteShareKey: '16bcb6bcff21e2fbcbad3fd5c5ca4605',
+  biteShareKey: '',
   nickname: null
 };
 

--- a/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
+++ b/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
@@ -1,18 +1,94 @@
 import React from 'react';
-import { View, Text, StyleSheet, Button } from 'react-native';
+import { View, Text, StyleSheet, Button, TouchableOpacity } from 'react-native';
+import { colors } from '../../../infrastructure/colors.js';
+
 
 const styles = StyleSheet.create({
   billsContainer: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
+  },
+
+  menuItemsContainer: {
+    backgroundColor: colors.brand.kazanLight2,
+    marginTop: 40,
+    padding: 40,
+    paddingTop: 60,
+    paddingBottom: 60,
+    borderRadius: 40
+  },
+
+  menuItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+
+  priceContainer: {
+    alignItems: 'center',
+    margin: 50
+  },
+
+  individualBill: {
+    paddingBottom: 10,
+    color: colors.brand.rausch,
+    fontWeight: 'bold'
+  },
+
+  tip: {
+    textAlign: 'center',
+    width: 300,
+    padding: 7,
+    marginBottom: 10,
+    backgroundColor: colors.brand.ebisu,
+    color: colors.brand.darkBlue
+  },
+
+  paymentButton: {
+    width: 150,
+    marginTop: 40,
+    padding: 15,
+    borderRadius: 50,
+    backgroundColor: colors.brand.ebisuLight,
+    borderColor: colors.brand.sessionTab,
+    borderWidth: 1
   }
 });
 
 const CurrentSessionBills = ({ changeTab }) => {
   return (
-    <View style = {styles.billsContainer}>
-      <Text>This is Bills Screen.</Text>
+    <View style={styles.billsContainer}>
+      <View style={styles.menuItemsContainer}>
+        <View style={styles.menuItem}>
+          <Text style={{ fontWeight: 'bold' }}>Mexican Food Item</Text>
+          <Text style={{ fontWeight: 'bold' }}>$13.95</Text>
+        </View>
+        <Text>the description of the menu item goes here</Text>
+      </View>
+
+      <View style={styles.priceContainer}>
+        <Text style={styles.individualBill}>Your share is: $14.95 (incl. tax)</Text>
+        <Text>Total bill is: $50.99</Text>
+      </View>
+
+      <View>
+        <TouchableOpacity>
+          <Text style={styles.tip}>Add 10% tip: $15</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity>
+          <Text style={styles.tip}>Add 15% tip: $17</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity>
+          <Text style={styles.tip}>Add 20% tip: $19</Text>
+        </TouchableOpacity>
+      </View>
+
+      <TouchableOpacity style={styles.paymentButton}>
+        <Text style={{ textAlign: 'center', color: colors.brand.rausch, fontWeight: 'bold' }}>Make Payment</Text>
+      </TouchableOpacity>
+
     </View>
   );
 };

--- a/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
+++ b/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Button, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Button, TouchableOpacity, FlatList } from 'react-native';
 import { colors } from '../../../infrastructure/colors.js';
 import { BiteShareContext } from '../../../BiteShareContext.js';
 import { getADocReferenceFromCollection, readASingleDocument } from '../../../../firebase/helpers/database.firebase.js';
-
+import OrderedItemInfo from './OrderedItemInfo.js';
 
 
 const styles = StyleSheet.create({
@@ -14,11 +14,13 @@ const styles = StyleSheet.create({
   },
 
   orderedItemsContainer: {
+    height: 200,
     backgroundColor: colors.brand.kazanLight2,
+    margin: 15,
     marginTop: 40,
     padding: 40,
-    paddingTop: 60,
-    paddingBottom: 60,
+    paddingTop: 20,
+    paddingBottom: 20,
     borderRadius: 40
   },
 
@@ -88,6 +90,10 @@ const CurrentSessionBills = ({ changeTab }) => {
       });
   };
 
+  //function to add tax
+
+  //function to add tip
+
   useEffect(() => {
     getIndividualBill();
     getTotalBill();
@@ -101,11 +107,14 @@ const CurrentSessionBills = ({ changeTab }) => {
   return (
     <View style={styles.billsContainer}>
       <View style={styles.orderedItemsContainer}>
-        <View style={styles.orderedItem}>
-          <Text style={{ fontWeight: 'bold' }}>Mexican Food Item</Text>
-          <Text style={{ fontWeight: 'bold' }}>$13.95</Text>
-        </View>
-        <Text>the description of the menu item goes here</Text>
+
+        <FlatList
+          data={orderedItems}
+          renderItem={({ item, index }) => <OrderedItemInfo orderedItem={item} />}
+          keyExtractor={(item, index) => index}
+          ItemSeparatorComponent={() => <View style={{ padding: 10 }}></View>}
+        />
+
       </View>
 
       <View style={styles.priceContainer}>

--- a/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
+++ b/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
@@ -24,14 +24,10 @@ const styles = StyleSheet.create({
     borderRadius: 40
   },
 
-  orderedItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-
   priceContainer: {
     alignItems: 'center',
-    margin: 50
+    margin: 50,
+    marginTop: 20
   },
 
   individualBill: {
@@ -90,9 +86,11 @@ const CurrentSessionBills = ({ changeTab }) => {
       });
   };
 
-  //function to add tax
+  //function to add tax- 7.25%
+  const addTax = (bill) => (bill * .0725) + bill;
 
   //function to add tip
+  const addTip = (bill, percent) => (bill * percent) + bill;
 
   useEffect(() => {
     getIndividualBill();
@@ -118,8 +116,8 @@ const CurrentSessionBills = ({ changeTab }) => {
       </View>
 
       <View style={styles.priceContainer}>
-        <Text style={styles.individualBill}>Your share is: $14.95 (incl. tax)</Text>
-        <Text>Total bill is: $50.99</Text>
+        <Text style={styles.individualBill}>{`Your share is: $${Math.trunc(addTax(individualBill))} (incl. tax)`}</Text>
+        <Text>{`Total bill is: $${Math.trunc(addTax(totalBill))}`}</Text>
       </View>
 
       <View>

--- a/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
+++ b/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 
 const CurrentSessionBills = ({ changeTab }) => {
 
-  const { state: { accountHolderName, sessionId, orderedItems }, dispatch } = useContext(BiteShareContext);
+  const { state: { accountHolderName, nickname, sessionId, orderedItems }, dispatch } = useContext(BiteShareContext);
   const [individualBill, setIndividualBill] = useState(0);
   const [totalBill, setTotalBill] = useState(0);
   const tipPercentages = [0.1, 0.15, 0.2];
@@ -60,7 +60,7 @@ const CurrentSessionBills = ({ changeTab }) => {
   const addTax = (bill) => (bill * .0725) + bill;
 
   const getIndividualBill = () => {
-    getADocReferenceFromCollection(`transactions/${sessionId}/attendees`, 'name', '==', accountHolderName)
+    getADocReferenceFromCollection(`transactions/${sessionId}/attendees`, 'name', '==', nickname || accountHolderName)
       .then((qResult) => {
         qResult.forEach((doc) => {
           readASingleDocument(`transactions/${sessionId}/attendees`, doc.id)
@@ -89,6 +89,8 @@ const CurrentSessionBills = ({ changeTab }) => {
   // console.log('orderedItems: ', orderedItems);
   // console.log('totalBill: ', totalBill);
 
+  const [selected, setSelected] = useState(null);
+
   return (
     <View style={styles.billsContainer}>
 
@@ -108,7 +110,15 @@ const CurrentSessionBills = ({ changeTab }) => {
 
       <FlatList
         data={tipPercentages}
-        renderItem={({ item, index }) => <TipInfo tipPercentage={item} individualBill={individualBill} />}
+        renderItem={
+          ({ item, index }) => <TipInfo
+            tipPercentage={item}
+            individualBill={individualBill}
+            index={index}
+            selected={selected}
+            setSelected={setSelected}
+          />
+        }
         keyExtractor={(item, index) => index}
         ItemSeparatorComponent={() => <View style={{ padding: 7 }}></View>}
         scrollEnabled={false}

--- a/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
+++ b/src/features/CurrentSessionView/currentSessionBills/CurrentSessionBills.Screen.js
@@ -102,8 +102,8 @@ const CurrentSessionBills = ({ changeTab }) => {
       </View>
 
       <View style={styles.priceContainer}>
-        <Text style={styles.individualBill}>{`Your share is: $${Math.trunc(addTax(individualBill))} (incl. tax)`}</Text>
-        <Text>{`Total bill is: $${Math.trunc(addTax(totalBill))} (incl. tax)`}</Text>
+        <Text style={styles.individualBill}>{`Your share is: $${addTax(individualBill).toFixed(2)} (incl. tax)`}</Text>
+        <Text>{`Total bill is: $${addTax(totalBill).toFixed(2)} (incl. tax)`}</Text>
       </View>
 
       <FlatList

--- a/src/features/CurrentSessionView/currentSessionBills/OrderedItemInfo.js
+++ b/src/features/CurrentSessionView/currentSessionBills/OrderedItemInfo.js
@@ -1,0 +1,29 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Button, TouchableOpacity, FlatList } from 'react-native';
+import { colors } from '../../../infrastructure/colors.js';
+import { BiteShareContext } from '../../../BiteShareContext.js';
+
+const styles = StyleSheet.create({
+  orderedItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  }
+});
+
+
+const OrderedItemInfo = ({ orderedItem }) => {
+  return (
+    <View>
+      <View style={styles.orderedItem}>
+        <View style={{ width: 200 }}>
+          <Text style={{ fontWeight: 'bold' }}>{orderedItem.name}</Text>
+
+        </View>
+        <Text style={{ fontWeight: 'bold' }}>${orderedItem.price}</Text>
+      </View>
+      <Text>{orderedItem.description}</Text>
+    </View>
+  );
+};
+
+export default OrderedItemInfo;

--- a/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
+++ b/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
@@ -29,7 +29,7 @@ const TipInfo = ({ individualBill, tipPercentage }) => {
 
   return (
     <Pressable onPress={toggle}>
-      <Text style={selected ? styles.tipSelected : styles.tip}>{`Add ${tipPercentage * 100}% tip: $${Math.trunc(addTip(individualBill, tipPercentage))}`}</Text>
+      <Text style={selected ? styles.tipSelected : styles.tip}>{`Add ${tipPercentage * 100}% tip: $${addTip(individualBill, tipPercentage).toFixed(2)}`}</Text>
     </Pressable>
   );
 };

--- a/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
+++ b/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Text, StyleSheet, Pressable } from 'react-native';
+import { colors } from '../../../infrastructure/colors.js';
+
+
+const styles = StyleSheet.create({
+  tip: {
+    textAlign: 'center',
+    width: 300,
+    padding: 7,
+    backgroundColor: colors.brand.ebisu,
+    color: colors.brand.darkBlue
+  },
+
+  tipSelected: {
+    textAlign: 'center',
+    width: 300,
+    padding: 7,
+    backgroundColor: colors.brand.rausch,
+    color: colors.brand.darkBlue
+  }
+});
+
+const TipInfo = ({ individualBill, tipPercentage }) => {
+  const [selected, setSelected] = useState(false);
+  const toggle = () => setSelected(prevSelected => !prevSelected);
+
+  const addTip = (bill, percent) => bill * percent;
+
+  return (
+    <Pressable onPress={toggle}>
+      <Text style={selected ? styles.tipSelected : styles.tip}>{`Add ${tipPercentage * 100}% tip: $${Math.trunc(addTip(individualBill, tipPercentage))}`}</Text>
+    </Pressable>
+  );
+};
+
+export default TipInfo;

--- a/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
+++ b/src/features/CurrentSessionView/currentSessionBills/TipInfo.js
@@ -21,15 +21,21 @@ const styles = StyleSheet.create({
   }
 });
 
-const TipInfo = ({ individualBill, tipPercentage }) => {
-  const [selected, setSelected] = useState(false);
-  const toggle = () => setSelected(prevSelected => !prevSelected);
-
+const TipInfo = ({ individualBill, tipPercentage, index, selected, setSelected }) => {
   const addTip = (bill, percent) => bill * percent;
 
   return (
-    <Pressable onPress={toggle}>
-      <Text style={selected ? styles.tipSelected : styles.tip}>{`Add ${tipPercentage * 100}% tip: $${addTip(individualBill, tipPercentage).toFixed(2)}`}</Text>
+    <Pressable onPress={() => {
+      if (index === selected) {
+        setSelected(null);
+      } else {
+        setSelected(index);
+      }
+    }}>
+      {index === selected ?
+        <Text style={styles.tipSelected}>{`Add ${tipPercentage * 100}% tip: $${addTip(individualBill, tipPercentage).toFixed(2)}`}</Text> :
+        <Text style={styles.tip}>{`Add ${tipPercentage * 100}% tip: $${addTip(individualBill, tipPercentage).toFixed(2)}`}</Text>
+      }
     </Pressable>
   );
 };

--- a/src/features/ExploreView/Explore.Screen.js
+++ b/src/features/ExploreView/Explore.Screen.js
@@ -85,15 +85,15 @@ const ExploreScreen = ({ navigation }) => {
     // console.log(zipcodeQuery);
   };
 
-  useEffect(() => {
-    const restaurantsData = mockRestaurants.data;
-    dispatch({ type: 'SET_RESTAURANTS', restaurants: restaurantsData });
-    getImages();
-  }, [mockRestaurants]);
+  // useEffect(() => {
+  //   const restaurantsData = mockRestaurants.data;
+  //   dispatch({ type: 'SET_RESTAURANTS', restaurants: restaurantsData });
+  //   getImages();
+  // }, [mockRestaurants]);
 
-  useEffect(() => {
-    return getLocation();
-  }, []);
+  // useEffect(() => {
+  //   return getLocation();
+  // }, []);
 
   return (
     <SafeArea>

--- a/src/features/ExploreView/Explore.Screen.js
+++ b/src/features/ExploreView/Explore.Screen.js
@@ -85,15 +85,15 @@ const ExploreScreen = ({ navigation }) => {
     // console.log(zipcodeQuery);
   };
 
-  // useEffect(() => {
-  //   const restaurantsData = mockRestaurants.data;
-  //   dispatch({ type: 'SET_RESTAURANTS', restaurants: restaurantsData });
-  //   getImages();
-  // }, [mockRestaurants]);
+  useEffect(() => {
+    const restaurantsData = mockRestaurants.data;
+    dispatch({ type: 'SET_RESTAURANTS', restaurants: restaurantsData });
+    getImages();
+  }, [mockRestaurants]);
 
-  // useEffect(() => {
-  //   return getLocation();
-  // }, []);
+  useEffect(() => {
+    return getLocation();
+  }, []);
 
   return (
     <SafeArea>


### PR DESCRIPTION
## Description
The Bills page is complete. Looks like this-- but with rounded bills. Most of the restaurants will also include item descriptions, but this particular one did not.

When you click on the tip, the tip box changes color to clearly show that it is selected.
The tip calculation is based on individual bill without the tax added to it.
The 'Make Payment' button has no functionality yet. It should redirect to the 'Profile' tab or a modal should pop up.
![Screen Shot 2022-01-04 at 7 50 55 PM](https://user-images.githubusercontent.com/75404942/148158610-4a843eb3-b11a-471d-9075-65cfcf46ba1f.png)

## How to test
Create a session, select menu items, ... , split the bill. When you are redirected to the Bills page, you should see a scrollable list of items only you ordered.

## Notes
<!-- Additional things reviewers should be aware of -->

## Issue tracking
<!-- Link to Trello ticket -->